### PR TITLE
Fix setup script and provide install docs

### DIFF
--- a/jupyterlab_wipp/README.md
+++ b/jupyterlab_wipp/README.md
@@ -96,6 +96,17 @@ By default, the `jlpm run build` command generates the source maps for this exte
 jupyter lab build --minimize=False
 ```
 
+### Manually build and upload release
+
+To manually build and publish prebuilt extension bundle, run the following commands (`jupyter_packaging` and `twine` are required)
+
+```bash
+pip install -e .
+python setup.py sdist bdist_wheel
+twine check dist/*
+twine upload dist/*
+```
+
 ### Development uninstall
 
 ```bash


### PR DESCRIPTION
The existing script is not handling the serer- and labextensions from Python bundle correctly (as when installing from pip). The change is following the PR here: https://github.com/jupyterlab/extension-cookiecutter-ts/pull/168